### PR TITLE
Bug fix in MAME keymapping of player2. Removed some sleeps to reduce …

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -2,6 +2,7 @@
  * Author: Bobby Dilley
  * Created: 2019
  * SPDX-FileCopyrightText: 2019 Bobby Dilley <bobby@dilley.uk>
+ * 2022 Contributor and DE10-Nano tester: Javier Rodas (@JaviRodasG) <javier.rodas@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  **/
 
@@ -14,7 +15,7 @@ int parseConfig(char *filePath, JVSConfig *jvsConfig)
 {
     // Setup default values
     jvsConfig->analogueFuzz = 2;
-    strcpy(jvsConfig->devicePath, "/dev/ttyUSB0");
+    strcpy(jvsConfig->devicePath, devicePath);
 
     FILE *fp;
     char buffer[1024];

--- a/src/device.c
+++ b/src/device.c
@@ -2,6 +2,7 @@
  * Author: Bobby Dilley
  * Created: 2019
  * SPDX-FileCopyrightText: 2019 Bobby Dilley <bobby@dilley.uk>
+ * 2022 Contributor and DE10-Nano tester: Javier Rodas (@JaviRodasG) <javier.rodas@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  **/
 

--- a/src/input.c
+++ b/src/input.c
@@ -2,6 +2,7 @@
  * Author: Bobby Dilley
  * Created: 2019
  * SPDX-FileCopyrightText: 2019 Bobby Dilley <bobby@dilley.uk>
+ * 2022 Contributor and DE10-Nano tester: Javier Rodas (@JaviRodasG) <javier.rodas@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  **/
 
@@ -32,7 +33,7 @@ struct uinput_user_dev usetup;
 int systemKeys[] = {KEY_F2, KEY_F2, KEY_F2, KEY_F2, KEY_F2, KEY_F2, KEY_F2, KEY_F2};
 int coinKeys[] = {KEY_5, KEY_6, KEY_6};
 int playerOneKeys[] = {KEY_1, KEY_9, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, KEY_LEFTCTRL, KEY_LEFTALT, KEY_SPACE, KEY_LEFTSHIFT, KEY_Z, KEY_X, KEY_C, KEY_V, KEY_V, KEY_V};
-int playerTwoKeys[] = {KEY_2, KEY_9, KEY_R, KEY_F, KEY_D, KEY_G, KEY_A, KEY_S, KEY_Q, KEY_W, KEY_I, KEY_J, KEY_J, KEY_L, KEY_L, KEY_L};
+int playerTwoKeys[] = {KEY_2, KEY_9, KEY_R, KEY_F, KEY_D, KEY_G, KEY_A, KEY_S, KEY_Q, KEY_W, KEY_I, KEY_K, KEY_J, KEY_L, KEY_L, KEY_L};
 
 void emit(int fd, int type, int code, int val)
 {
@@ -87,11 +88,10 @@ int initInput(JVSCapabilities *sentCapabilities, char *name, int analogueFuzz)
             ioctl(fd, UI_SET_KEYBIT, playerTwoKeys[i]);
     }
 
-    ioctl(fd, UI_SET_EVBIT, EV_ABS);
-    for (int i = 0; i < capabilities->analogueInChannels; i++)
-    {
-        ioctl(fd, UI_SET_ABSBIT, i);
-    }
+//    ioctl(fd, UI_SET_EVBIT, EV_ABS);
+//    for (int i = 0; i < capabilities->analogueInChannels; i++) {
+//        ioctl(fd, UI_SET_ABSBIT, i);
+//    }
 
     memset(&usetup, 0, sizeof(usetup));
     usetup.id.bustype = BUS_USB;
@@ -184,11 +184,10 @@ int updateSwitches(unsigned char *switches)
  * 
  * @param switches The raw byte array containing analogue values
  */
-int updateAnalogues(int *analogues)
-{
-    for (int i = 0; i < capabilities->analogueInChannels; i++)
-    {
+int updateAnalogues(int *analogues) {
+    for (int i = 0; i < capabilities->analogueInChannels; i++) {
         emit(fd, EV_ABS, i, analogues[i] >> (16 - capabilities->analogueInBits));
+        sendUpdate();
     }
     return 1;
 }
@@ -205,6 +204,7 @@ int emitCoinPress(unsigned char slot)
 {
     emit(fd, EV_KEY, coinKeys[slot], 1);
     sendUpdate();
+    usleep(100*1000);
     emit(fd, EV_KEY, coinKeys[slot], 0);
     sendUpdate();
     return 1;

--- a/src/jvs.c
+++ b/src/jvs.c
@@ -2,6 +2,7 @@
  * Author: Bobby Dilley
  * Created: 2019
  * SPDX-FileCopyrightText: 2019 Bobby Dilley <bobby@dilley.uk>
+ * 2022 Contributor and DE10-Nano tester: Javier Rodas (@JaviRodasG) <javier.rodas@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  **/
 
@@ -320,7 +321,7 @@ int runCommand(JVSPacket *outputPacket, JVSPacket *inputPacket)
 			continue;
 		}
 
-		usleep(500);
+//		usleep(500);
 
 		JVSStatus readPacketResponse = readPacket(inputPacket);
 		if (readPacketResponse != JVS_STATUS_SUCCESS)
@@ -354,7 +355,7 @@ int runCommand(JVSPacket *outputPacket, JVSPacket *inputPacket)
 			continue;
 		}
 
-		usleep(10 * 1000);
+//		usleep(10 * 1000);
 
 		return 1;
 	}

--- a/src/jvscore.c
+++ b/src/jvscore.c
@@ -2,6 +2,7 @@
  * Author: Bobby Dilley
  * Created: 2019
  * SPDX-FileCopyrightText: 2019 Bobby Dilley <bobby@dilley.uk>
+ * 2022 Contributor and DE10-Nano tester: Javier Rodas (@JaviRodasG) <javier.rodas@gmail.com>
  * SPDX-License-Identifier: GPL-3.0-or-later
  **/
 
@@ -126,17 +127,19 @@ int main()
         /* Update the switches */
         if (capabilities.switches > 0)
         {
+//            for(int i = 0 ; i < getSwitchBytesPerPlayer() * capabilities.players + 1 ; i++) {
+//                printf("%d ", switches[i]);
+//            }
+//            printf("\n");
             updateSwitches(switches);
+            sendUpdate();
         }
 
         /* Update the analogue channels */
-        if (capabilities.analogueInChannels > 0)
-        {
-            updateAnalogues(analogues);
-        }
-
-        /* Send the updates to the computer */
-        sendUpdate();
+//        if (capabilities.analogueInChannels > 0)
+//        {
+//            updateAnalogues(analogues);
+//        }
     }
 
     closeInput();


### PR DESCRIPTION
Bug fix in MAME keymapping of player2. Removed some sleeps to reduce input lag. Verified the input lag with a DE10-Nano+NES_Lag_Tester. Disabled the updateAnalogues, which cause trouble in the DE10-Nano. Bug fix in config file devicePath variable not being used. Updated some sendUpdate call places. Added Javier Rodas as contributor and DE10-Nano tester.